### PR TITLE
SAP-4320: Rename package for upload to devpi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -414,9 +414,9 @@ Operating System :: MacOS
 """
     
 metadata = {
-    'name': "pysam",
+    'name': "pysam-congenica",
     'version': get_pysam_version(),
-    'description': "pysam",
+    'description': "pysam congenica fork",
     'long_description': __doc__,
     'author': "Andreas Heger",
     'author_email': "andreas.heger@gmail.com",


### PR DESCRIPTION
Pipenv doesn't cope with the same package and version in pypi and our
devpi server as it always favours the pypi version. The solution is to
rename our forked version of the pysam package so that the package
doesn't clash with the pypi version.